### PR TITLE
#40847 本家JupyterHubのHelmチャートへの追従

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -62,7 +62,7 @@ jupyterhub:
     cors: *cors
     binderauth_enabled: false
   rbac:
-    enabled: true
+    create: true
   hub:
     config:
       JupyterHub:


### PR DESCRIPTION
#40847に関連してBinderhubのHelmチャートの修正
本家の3.2.1のタグをマージした。
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/releases/tag/3.2.1