### PR TITLE
[GRDM-42361] binderhubでビルドエラーが発生する

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
   - name: jupyterhub
-    version: "3.2.1-20240209"
+    version: "3.2.1-20240401"
     repository: "https://rcosdp.github.io/CS-jhub-helm-chart/"

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -27,6 +27,9 @@ WORKDIR /tmp/binderhub
 RUN python setup.py bdist_wheel
 RUN pip wheel pycurl --wheel-dir ./dist
 
+# Run the script
+RUN mkdir -p /etc/pki/tls/certs/ && ln -s /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
+
 
 # The final stage
 # ---------------
@@ -49,6 +52,8 @@ RUN apt-get update \
         git build-essential \
  && rm -rf /var/lib/apt/lists/*
 
+# Run the script
+RUN mkdir -p /etc/pki/tls/certs/ && ln -s /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
 
 # Copy the built wheels from the build-stage. Also copy the image
 # requirements.txt built from the binderhub package requirements.txt and the


### PR DESCRIPTION
・最新のpycurlの問題により、binderhubにてビルドエラーが発生する件に対して
Dockerfileにworkaroundの内容を追加した
https://github.com/pycurl/pycurl/issues/834

・依存するjupyterhubのバージョンを最新に変更した