### PR TITLE
バージョンアップ・依存更新・問い合わせ先変更（binderhub, image-cleaner, index.html）

### DIFF
--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -156,8 +156,8 @@
           </div>
         </div>
         <div style="text-align: right">
-          →<a href="https://meatwiki.nii.ac.jp/confluence/pages/viewpage.action?pageId=88607901" target="_blank" rel="noopener noreferrer">問い合わせ先/エラーが発生したときは</a><br>
-          →<a href="https://meatwiki.nii.ac.jp/confluence/x/joJyBQ" target="_blank" rel="noopener noreferrer">Contact Information/Troubleshooting</a>
+          →<a href="https://jdcat.jsps.go.jp/analysis-In-case-of-error.html" target="_blank" rel="noopener noreferrer">問い合わせ先/エラーが発生したときは</a><br>
+          →<a href="https://jdcat.jsps.go.jp/analysis-In-case-of-error.html" target="_blank" rel="noopener noreferrer">Contact Information/Troubleshooting</a>
         </div>
 
         <div id="log-container" class="panel panel-default on-build hidden row">

--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A helm chart to install Binder
 name: binderhub
-version: 0.2.0-jhub-1.1.3
+version: 0.2.5-20240816

--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A helm chart to install Binder
 name: binderhub
-version: 0.2.5-20240816
+version: 0.2.5-20251020

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -16,7 +16,7 @@ nodeSelector: {}
 
 image:
   name: gcr.io/nii-ap-ops/k8s-binderhub-binderhub
-  tag: '0.2.0-jhub-1.1.3'
+  tag: '0.2.5-20240816'
 
 # registry here is only used to create docker config.json
 registry:
@@ -176,7 +176,7 @@ imageCleaner:
   enabled: true
   image:
     name: gcr.io/nii-ap-ops/k8s-binderhub-image-cleaner
-    tag: '0.2.0-jhub-1.1.3'
+    tag: '0.2.5-20240816'
     repository: gcr.io/nii-ap-ops/k8s-binderhub-image-cleaner
   # delete an image at most every 5 seconds
   delay: 5

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -16,7 +16,7 @@ nodeSelector: {}
 
 image:
   name: gcr.io/nii-ap-ops/k8s-binderhub-binderhub
-  tag: '0.2.5-20240816'
+  tag: '0.2.5-20251020'
 
 # registry here is only used to create docker config.json
 registry:
@@ -176,7 +176,7 @@ imageCleaner:
   enabled: true
   image:
     name: gcr.io/nii-ap-ops/k8s-binderhub-image-cleaner
-    tag: '0.2.5-20240816'
+    tag: '0.2.5-20251020'
     repository: gcr.io/nii-ap-ops/k8s-binderhub-image-cleaner
   # delete an image at most every 5 seconds
   delay: 5

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -1,17 +1,17 @@
 # We use a build stage to package binderhub and pycurl into a wheel which we
 # then install by itself in the final image which is relatively slimmed.
-ARG DIST=buster
+ARG DIST=bullseye
 
 
 # The build stage
 # ---------------
-FROM python:3.8-$DIST as build-stage
+FROM python:3.9-$DIST AS build-stage
 # ARG DIST is defined again to be made available in this build stage's scope.
 # ref: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG DIST
 
 # Install node as required to package binderhub to a wheel
-RUN echo "deb http://deb.nodesource.com/node_14.x $DIST main" > /etc/apt/sources.list.d/nodesource.list \
+RUN echo "deb http://deb.nodesource.com/node_18.x $DIST main" > /etc/apt/sources.list.d/nodesource.list \
  && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN apt-get update \
  && apt-get install --yes \
@@ -33,13 +33,13 @@ RUN mkdir -p /etc/pki/tls/certs/ && ln -s /etc/ssl/certs/ca-certificates.crt /et
 
 # The final stage
 # ---------------
-FROM python:3.8-$DIST
+FROM python:3.9-$DIST
 WORKDIR /
 
 ARG DIST
 
 # Install node as required to package binderhub to a wheel
-RUN echo "deb http://deb.nodesource.com/node_14.x $DIST main" > /etc/apt/sources.list.d/nodesource.list \
+RUN echo "deb http://deb.nodesource.com/node_18.x $DIST main" > /etc/apt/sources.list.d/nodesource.list \
  && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN apt-get update \
  && apt-get install --yes \
@@ -62,7 +62,7 @@ COPY --from=build-stage /tmp/binderhub/dist/*.whl pre-built-wheels/
 COPY helm-chart/images/binderhub/requirements.txt .
 
 RUN pip install --no-cache-dir cliapp
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash 
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash 
 RUN apt install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 RUN npm install --global yarn

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    ./dependencies freeze --upgrade
 #
-alembic==1.5.4
+alembic==1.7.5
     # via jupyterhub
 async-generator==1.10
     # via jupyterhub
@@ -12,7 +12,7 @@ attrs==20.3.0
     # via jsonschema
 cachetools==4.2.1
     # via google-auth
-certifi==2020.12.5
+certifi==2021.10.8
     # via
     #   kubernetes
     #   requests
@@ -22,9 +22,9 @@ cffi==1.14.4
     # via cryptography
 chardet==4.0.0
     # via requests
-cryptography==3.4.4
+cryptography==3.4.8
     # via pyopenssl
-docker==4.4.1
+docker==4.4.4
     # via -r binderhub.in
 entrypoints==0.3
     # via jupyterhub
@@ -65,7 +65,7 @@ git+https://github.com/RCOSDP/CS-jupyterhub.git@master
     # via
     #   -r binderhub.in
     #   -r requirements.in
-kubernetes==9.0.1
+kubernetes==12.0.1
     # via
     #   -r binderhub.in
     #   -r requirements.in
@@ -81,7 +81,7 @@ oauthlib==3.1.0
     #   requests-oauthlib
 packaging==20.9
     # via google-api-core
-pamela==1.0.0
+pamela==1.1.0
     # via jupyterhub
 prometheus-client==0.9.0
     # via
@@ -148,7 +148,7 @@ six==1.15.0
     #   pyopenssl
     #   python-dateutil
     #   websocket-client
-sqlalchemy==1.3.23
+sqlalchemy==1.4.25
     # via
     #   alembic
     #   jupyterhub
@@ -161,7 +161,7 @@ traitlets==5.0.5
     #   -r binderhub.in
     #   jupyter-telemetry
     #   jupyterhub
-urllib3==1.26.3
+urllib3==1.26.5
     # via
     #   kubernetes
     #   requests

--- a/helm-chart/images/image-cleaner/Dockerfile
+++ b/helm-chart/images/image-cleaner/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster
+FROM python:3.9-slim-bullseye
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt

--- a/helm-chart/images/image-cleaner/requirements.txt
+++ b/helm-chart/images/image-cleaner/requirements.txt
@@ -1,2 +1,2 @@
-docker==4.1.0
+docker>=5.0.0
 kubernetes==10.0.1

--- a/helm-chart/images/image-cleaner/requirements.txt
+++ b/helm-chart/images/image-cleaner/requirements.txt
@@ -1,2 +1,2 @@
-docker>=5.0.0
+docker==7.1.0
 kubernetes==10.0.1

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "file-loader": "^1.1.6",
     "jquery": "^3.2.1",
     "style-loader": "^0.19.1",
-    "webpack": "^3.10.0",
     "xterm": "^2.9.2"
   },
   "scripts": {
@@ -27,5 +26,8 @@
   "bugs": {
     "url": "https://github.com/jupyterhub/binderhub/issues"
   },
-  "homepage": "https://github.com/jupyterhub/binderhub#readme"
+  "homepage": "https://github.com/jupyterhub/binderhub#readme",
+  "dependencies": {
+    "webpack": "^3.12.0"
+  }
 }


### PR DESCRIPTION
### 主な変更点
- Helmチャートのバージョン・イメージタグを 0.2.5-20251020 に更新
- binderhub, image-cleaner のDockerfileをbullseye/Node.js 18.x/Python 3.9系にアップデート
- requirements.txtの依存パッケージを最新の安定バージョンに更新
- index.htmlの問い合わせ先リンクを meatwiki → jdcat.jsps.go.jp に変更

### 目的
- セキュリティ・保守性向上のためのベースイメージ・依存パッケージの更新
- 問い合わせ先の最新化