### PR TITLE
Open SSL手動ビルド更新取り消し

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -457,10 +457,10 @@ jobs:
         run: |
           cd testing/local-binder-local-hub
           jupyterhub --config=jupyterhub_config.py > jupyterhub.log 2>&1 &
-          sleep 5
+          sleep 15
 
           echo curl http://localhost:8000/hub/api/ should print the JupyterHub version
-          curl http://localhost:8000/hub/api/ --max-time 5 --retry 5 --retry-delay 1 --retry-connrefused --fail-with-body --retry-all-errors
+          curl http://localhost:8000/hub/api/ --max-time 10 --retry 5 --retry-delay 3 --retry-connrefused --fail-with-body --retry-all-errors
 
       - name: Run remote tests
         run: |

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -357,7 +357,7 @@ class FigshareProvider(RepoProvider):
         "ref": {"enabled": False},
     }
 
-    url_regex = re.compile(r"(.*)/articles/([^/]+)/([^/]+)/(\d+)(/)?(\d+)?")
+    url_regex = re.compile(r"(.*)/articles/([^/]+)/(\d+)(/)?(\d+)?")
 
     async def get_resolved_ref(self):
         client = AsyncHTTPClient()
@@ -365,8 +365,8 @@ class FigshareProvider(RepoProvider):
         r = await client.fetch(req)
 
         match = self.url_regex.match(r.effective_url)
-        article_id = match.groups()[3]
-        article_version = match.groups()[5]
+        article_id = match.groups()[2]
+        article_version = match.groups()[4]
         if not article_version:
             article_version = "1"
         self.record_id = f"{article_id}.v{article_version}"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ chartpress>=2.1
 click
 dockerspawner
 jsonschema
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
 jupyter_packaging>=0.10.4,<2
 jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1
 nest-asyncio

--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -1,7 +1,7 @@
 # Chart.yaml v2 reference: https://helm.sh/docs/topics/charts/#the-chartyaml-file
 apiVersion: v2
 name: binderhub
-version: 0.2.5-20260304.2
+version: 0.2.5-20260304.3
 dependencies:
   # Source code:    https://github.com/jupyterhub/zero-to-jupyterhub-k8s
   # Latest version: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
@@ -12,7 +12,7 @@ dependencies:
   #            and run "./dependencies freeze --upgrade".
   #
   - name: jupyterhub
-    version: "4.1.0-20260304"
+    version: "4.1.0-20260304.2"
     repository: "https://rcosdp.github.io/CS-jhub-helm-chart/"
 description: |-
   BinderHub is like a JupyterHub that automatically builds environments for the

--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -1,7 +1,7 @@
 # Chart.yaml v2 reference: https://helm.sh/docs/topics/charts/#the-chartyaml-file
 apiVersion: v2
 name: binderhub
-version: 0.2.5-20251121.3
+version: 0.2.5-20260304.2
 dependencies:
   # Source code:    https://github.com/jupyterhub/zero-to-jupyterhub-k8s
   # Latest version: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
@@ -12,7 +12,7 @@ dependencies:
   #            and run "./dependencies freeze --upgrade".
   #
   - name: jupyterhub
-    version: "4.1.0-20251118.2"
+    version: "4.1.0-20260304"
     repository: "https://rcosdp.github.io/CS-jhub-helm-chart/"
 description: |-
   BinderHub is like a JupyterHub that automatically builds environments for the

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -68,22 +68,6 @@ RUN apt-get update \
               # or "kubectl delete pod" is run. By doing that the pod can
               # terminate very quickly.
         curl gpg \
-        # OpenSSL コンパイル用
-        build-essential \
-        wget \
-        zlib1g-dev \
-        ca-certificates \
- && wget -O /tmp/ssl-source.tar.gz https://www.openssl.org/source/openssl-3.0.18.tar.gz \
- && tar -xzf /tmp/ssl-source.tar.gz -C /tmp \
- && (cd /tmp/openssl-3.0.18 && ./Configure --prefix=/usr/local --openssldir=/etc/ssl --libdir=lib shared zlib-dynamic) \
- && (cd /tmp/openssl-3.0.18 && make -j$(nproc)) \
- && (cd /tmp/openssl-3.0.18 && make install_sw) \
- && echo "/usr/local/lib" > /etc/ld.so.conf.d/openssl-3.0.18.conf \      
- && ldconfig \
- && rm -f /tmp/ssl-source.tar.gz \
- && rm -rf /tmp/openssl-3.0.18 \
- && apt-get remove -y build-essential wget zlib1g-dev \
- && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/*
 
 # Workaround: CS-jupyterhub requires nodejs and npm to be installed.

--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -12,7 +12,7 @@ google-cloud-logging==3.*
 jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1
 
 # jupyter-repo2docker is pinned to CS-repo2docker
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
 
 # Workaround: Added a dependecy of ruamel-yaml because jupyter-telemetry,
 # which has a dependency of ruamel-yaml, was removed from jupyterhub.

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -123,7 +123,7 @@ jsonschema-specifications==2025.9.1
     # via jsonschema
 jupyter-events==0.12.0
     # via jupyterhub
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   -r helm-chart/images/binderhub/requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ escapism
 jinja2
 jsonschema
 jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
 kubernetes
 prometheus_client
 pyjwt>=2

--- a/testing/local-binder-local-hub/requirements.txt
+++ b/testing/local-binder-local-hub/requirements.txt
@@ -1,3 +1,3 @@
 dockerspawner>=12
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
 jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1


### PR DESCRIPTION
・pythonパッケージにopenssl 3.0.18が標準搭載されているため、3.0.18の手動ビルドの更新をRevert
・https://github.com/RCOSDP/CS-binderhub/pull/27の更新を取り込み